### PR TITLE
Rename java_opts to jvmflags

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,7 +26,7 @@ class zookeeper::server (
   $max_client_cnxns     = undef,
   $max_session_timeout  = undef,
   $leader_serves        = undef,
-  $java_opts            = undef,
+  $jvmflags             = undef,
   $manage_alternatives  = $::zookeeper::params::manage_alternatives,
   $template_zoocfg      = 'zookeeper/zoo.cfg.erb',
   $template_environment = 'zookeeper/environment.erb',

--- a/templates/environment.erb
+++ b/templates/environment.erb
@@ -17,4 +17,4 @@ JAVA=/usr/bin/java
 ZOOMAIN="org.apache.zookeeper.server.quorum.QuorumPeerMain"
 ZOO_LOG4J_PROP="INFO,ROLLINGFILE"
 JMXLOCALONLY=false
-JAVA_OPTS="<%= @java_opts %>"
+JVMFLAGS="<%= @jvmflags %>"


### PR DESCRIPTION
ZooKeeper RPM systemd unitfile reads `$JVMFLAGS` and not `$JAVA_OPTS`.